### PR TITLE
Remove asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pydantic
 requests
 aiohttp
-asyncio


### PR DESCRIPTION
`asyncio` is a [standard](https://docs.python.org/3/library/asyncio.html) module.