### PR TITLE
Update setup.py, exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/jeeftor/intellifire4py",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*']),
     install_requires=['aiohttp', 'pydantic', 'requests'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
otherwise a package called 'tests' would be installed at top level.

```
>>> Jobs: 1 of 2 complete, 1 failed                 Load avg: 2.09, 0.85, 0.46
 * Package:    dev-python/intellifire4py-0.9.9
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking intellifire4py-0.9.9.tar.gz to /var/tmp/portage/dev-python/intellifire4py-0.9.9/work
>>> Source unpacked in /var/tmp/portage/dev-python/intellifire4py-0.9.9/work
>>> Preparing source in /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
/usr/lib/python3.9/site-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
running build
running build_py
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests
copying tests/test_intellifire.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests
copying tests/test_model.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests
copying tests/testSha.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/const.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/udp.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/model.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/__init__.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/intellifire_async.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/intellifire.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/control_async.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
copying intellifire4py/control.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/intellifire4py-0.9.9

>>> Install dev-python/intellifire4py-0.9.9 into /var/tmp/portage/dev-python/intellifire4py-0.9.9/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9
/usr/lib/python3.9/site-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
running install
/usr/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running install_lib
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests/test_intellifire.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests/__init__.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests/test_model.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/tests/testSha.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests
creating /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/const.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/udp.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/model.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/__init__.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/intellifire_async.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/intellifire.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/control_async.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
copying /var/tmp/portage/dev-python/intellifire4py-0.9.9/work/intellifire4py-0.9.9-python3_9/lib/intellifire4py/control.py -> /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_intellifire.py to test_intellifire.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_model.py to test_model.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/tests/testSha.py to testSha.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/const.py to const.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/udp.py to udp.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/model.py to model.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/intellifire_async.py to intellifire_async.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/intellifire.py to intellifire.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/control_async.py to control_async.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py/control.py to control.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpce6nppqk.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpce6nppqk.py
removing /var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpce6nppqk.py
writing byte-compilation script '/var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpmj6lgl0f.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpmj6lgl0f.py
removing /var/tmp/portage/dev-python/intellifire4py-0.9.9/temp/tmpmj6lgl0f.py
running install_egg_info
running egg_info
writing intellifire4py.egg-info/PKG-INFO
writing dependency_links to intellifire4py.egg-info/dependency_links.txt
writing requirements to intellifire4py.egg-info/requires.txt
writing top-level names to intellifire4py.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'intellifire4py.egg-info/SOURCES.txt'
adding license file 'LICENSE.txt'
writing manifest file 'intellifire4py.egg-info/SOURCES.txt'
Copying intellifire4py.egg-info to /var/tmp/portage/dev-python/intellifire4py-0.9.9/image/_python3.9/usr/lib/python3.9/site-packages/intellifire4py-0.9.9-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/intellifire4py-0.9.9::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
```