### PR TITLE
G2-1700 Add support for external polling without background polling

### DIFF
--- a/src/intellifire4py/unified_fireplace.py
+++ b/src/intellifire4py/unified_fireplace.py
@@ -49,6 +49,8 @@ class UnifiedFireplace:
     cloud_connectivity: bool | None = None
     local_connectivity: bool | None = None
 
+    _polling_enabled: bool
+
     def __init__(
         self,
         fireplace_data: IntelliFireCommonFireplaceData,
@@ -56,6 +58,7 @@ class UnifiedFireplace:
         control_mode: IntelliFireApiMode = IntelliFireApiMode.LOCAL,
         use_http: bool = False,
         verify_ssl: bool = True,
+        polling_enabled: bool = True,
     ):
         """Initializes a new instance of the UnifiedFireplace class, configuring it for both local and cloud interactions with an IntelliFire fireplace.
 
@@ -81,6 +84,7 @@ class UnifiedFireplace:
 
         self._verify_ssl = verify_ssl
         self._use_http = use_http
+        self._polling_enabled = polling_enabled
 
         self._local_api: IntelliFireAPILocal = IntelliFireAPILocal(
             fireplace_ip=self.ip_address, user_id=self.user_id, api_key=self.api_key
@@ -109,6 +113,19 @@ class UnifiedFireplace:
         """
         await self._local_api.poll(timeout_seconds=timeout_seconds)
 
+    async def perform_poll(self, timeout_seconds: float = 10.0) -> None:
+        """Perform a poll of the correct API based on the current read mode.
+
+        Use data() to get the data after this completes.
+
+        Parameters:
+        timeout_seconds (float): The timeout in seconds for the cloud poll request.
+        """
+        if self.read_mode == IntelliFireApiMode.LOCAL:
+            await self.perform_local_poll(timeout_seconds)
+        else:
+            await self.perform_cloud_poll(timeout_seconds)
+
     @property
     def is_cloud_polling(self) -> bool:
         """Returns True if the cloud API is currently polling in the background."""
@@ -118,6 +135,11 @@ class UnifiedFireplace:
     def is_local_polling(self) -> bool:
         """Returns True if the local API is currently polling in the background."""
         return self._local_api.is_polling_in_background
+
+    @property
+    def is_polling_enabled(self) -> bool:
+        """Returns True if background polling is enabled."""
+        return self._polling_enabled
 
     def get_user_data_as_json(self) -> str:
         """Dump the internal _fireplace_data object to a JSON String."""
@@ -271,13 +293,17 @@ class UnifiedFireplace:
         selected mode. It's designed to be an internal method, not exposed externally.
         """
         if mode == IntelliFireApiMode.LOCAL:
-            await self._cloud_api.stop_background_polling()
+            if self._polling_enabled:
+                await self._cloud_api.stop_background_polling()
             self._local_api.overwrite_data(self._cloud_api.data)
-            await self._local_api.start_background_polling()
+            if self._polling_enabled:
+                await self._local_api.start_background_polling()
         elif mode == IntelliFireApiMode.CLOUD:
-            await self._local_api.stop_background_polling()
+            if self._polling_enabled:
+                await self._local_api.stop_background_polling()
             self._cloud_api.overwrite_data(self._local_api.data)
-            await self._cloud_api.start_background_polling()
+            if self._polling_enabled:
+                await self._cloud_api.start_background_polling()
         else:
             await self._local_api.stop_background_polling()
             await self._cloud_api.stop_background_polling()
@@ -360,6 +386,7 @@ class UnifiedFireplace:
         desired_control_mode: IntelliFireApiMode | None = None,
         use_http: bool = False,
         verify_ssl: bool = True,
+        polling_enabled: bool = True,
     ) -> UnifiedFireplace:
         """Asynchronously creates an instance of the class with specified fireplace data and operating modes.
 
@@ -393,6 +420,7 @@ class UnifiedFireplace:
             control_mode=IntelliFireApiMode.NONE,
             verify_ssl=verify_ssl,
             use_http=use_http,
+            polling_enabled=polling_enabled,
         )
         local_connect, cloud_connect = await instance.async_validate_connectivity(
             timeout=30
@@ -556,6 +584,7 @@ class UnifiedFireplace:
         common_fireplace: IntelliFireCommonFireplaceData,
         use_http: bool = False,
         verify_ssl: bool = True,
+        polling_enabled: bool = True,
     ) -> UnifiedFireplace:
         """Asynchronously creates a UnifiedFireplace instance from a common fireplace data structure.
 
@@ -578,6 +607,7 @@ class UnifiedFireplace:
             common_fireplace,
             use_http=use_http,
             verify_ssl=verify_ssl,
+            polling_enabled=polling_enabled,
             desired_read_mode=common_fireplace.read_mode,
             desired_control_mode=common_fireplace.control_mode,
         )


### PR DESCRIPTION
See https://github.com/jeeftor/intellifire4py/issues/238 for a description of why, but the bottom line is that this should allow HA integration to use its own polling, which will improved responsiveness.  I'm still testing, of course.