### PR TITLE
fix: improve intellifire command reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Command failure handling**: Local and cloud command calls now raise typed command errors when credentials are missing, when cloud control is rejected, or when local retries are exhausted. This prevents optimistic cached state updates when a fireplace command was not actually accepted.
+
+### Fixed
+
+- **Cloud session management**: Cloud APIs can now use a caller-provided `aiohttp.ClientSession` without taking ownership of it, and library-created sessions now apply explicit timeouts and SSL verification settings.
+
 ### Tests
 
 - **Coverage improvements**: Increased test coverage from 95% to 96% overall; production modules `cloud_api.py`, `local_api.py`, and `udp.py` now at 100%

--- a/intellifire4py/cloud_api.py
+++ b/intellifire4py/cloud_api.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 import time
 import asyncio
 from datetime import datetime, timezone
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from asyncio import Task
 from typing import Any
 import json
 import aiohttp
-from aiohttp import CookieJar, ClientSession, ClientTimeout
+from aiohttp import CookieJar, ClientSession, ClientTimeout, TCPConnector
 
-from .exceptions import CloudError
+from .exceptions import CloudError, CommandRejectedError, MissingCredentialsError
 from .model import (
     IntelliFireUserData,
 )
@@ -39,6 +41,7 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
         use_http: bool = False,
         verify_ssl: bool = True,
         cookie_jar: CookieJar | None = None,
+        session: ClientSession | None = None,
     ):
         """Initialize the class with specific configuration for fireplace communication.
 
@@ -60,6 +63,8 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
             cookie_jar (CookieJar): A `Cookies` object containing authentication or session cookies required for
                           communicating with the fireplace. This is essential for maintaining a secure and
                           authenticated session.
+            session (ClientSession | None): Optional externally managed aiohttp session. When provided, the caller
+                          remains responsible for closing it.
 
         Note:
             Modifying `use_http` and `verify_ssl` from their default values should be done with caution, as
@@ -72,6 +77,8 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
         self._log = logging.getLogger(__name__)
 
         self._cookie_jar = cookie_jar
+        self._session = session
+        self._owns_session = False
 
         if use_http:
             self.prefix = "http"  # pragma: no cover
@@ -90,12 +97,32 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
 
     def _get_session(self, timeout_seconds: float = 10.0) -> ClientSession:
         """Ensure that the aiohttp ClientSession is created and open."""
-        timeout = ClientTimeout(timeout_seconds)
+        timeout = ClientTimeout(total=timeout_seconds)
         return aiohttp.ClientSession(
             timeout=timeout,
             headers={"user-agent": USER_AGENT},
             cookie_jar=self._cookie_jar,
+            connector=TCPConnector(ssl=self._verify_ssl),
         )
+
+    @asynccontextmanager
+    async def _session_context(
+        self, timeout_seconds: float = 10.0
+    ) -> AsyncIterator[ClientSession]:
+        """Yield a session without closing caller-owned sessions."""
+        if self._session is not None:
+            if self._session.closed:
+                raise RuntimeError("Session is closed")
+            yield self._session
+            return
+
+        async with self._get_session(timeout_seconds=timeout_seconds) as session:
+            yield session
+
+    async def close_session(self) -> None:
+        """Close the session only when this instance owns it."""
+        if self._owns_session and self._session and not self._session.closed:
+            await self._session.close()
 
     def get_data(self) -> IntelliFirePollData:
         """Return data to the user."""
@@ -120,7 +147,7 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
                 command.name,
                 value,
             )
-            return
+            raise MissingCredentialsError("Missing cloud authentication cookies")
 
         await self._send_cloud_command(command=command, value=value)
 
@@ -129,40 +156,53 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
         *,
         command: IntelliFireCommand,
         value: int,
+        timeout_seconds: float = 10.0,
     ) -> None:
         url = f"{self.prefix}://iftapi.net/a/{self._serial}//apppost"
         content = f"{command.value['cloud_command']}={value}".encode()
 
-        async with self._get_session().post(url, data=content) as response:
-            self._log.info(f">> Created Session {response}")
+        async with self._session_context(timeout_seconds=timeout_seconds) as session:
+            async with session.post(
+                url,
+                data=content,
+                timeout=ClientTimeout(total=timeout_seconds),
+            ) as response:
+                self._log.info(f">> Created Session {response}")
 
-            curl_command = await _convert_aiohttp_response_to_curl(response)
-            self._log.debug(f"Generated curl command: {curl_command}")
-            response.raise_for_status()
+                curl_command = await _convert_aiohttp_response_to_curl(response)
+                self._log.debug(f"Generated curl command: {curl_command}")
+                try:
+                    response.raise_for_status()
+                except aiohttp.ClientResponseError as error:
+                    raise CommandRejectedError(
+                        f"Command {command.name} was rejected with status {error.status}"
+                    ) from error
 
-            log_msg = f"POST {url} [{content.decode()}]  [{self._cookie_jar}]"
-            self._log.debug(log_msg)
-            """
-            204 Success – command accepted
-            403 Not authorized (bad email address or authorization cookie)
-            404 Fireplace not found (bad serial number)
-            422 Invalid Parameter (invalid command id or command value)
-            """
-            if response.status == 204:
-                self._last_send = datetime.now(timezone.utc)
-                return
-            # elif (
-            #     response.status == 403
-            # ):  # Not authorized (bad email address or authorization cookie)
-            #     raise CloudError("Not authorized")
-            # elif response.status == 404:
-            #     raise CloudError("Fireplace not found (bad serial number)")
-            # elif response.status == 422:
-            #     raise CloudError(
-            #         "Invalid Parameter (invalid command id or command value)"
-            #     )
-            else:
-                raise Exception(f"Unexpected return code {response.status}")
+                log_msg = f"POST {url} [{content.decode()}]  [{self._cookie_jar}]"
+                self._log.debug(log_msg)
+                """
+                204 Success – command accepted
+                403 Not authorized (bad email address or authorization cookie)
+                404 Fireplace not found (bad serial number)
+                422 Invalid Parameter (invalid command id or command value)
+                """
+                if response.status == 204:
+                    self._last_send = datetime.now(timezone.utc)
+                    return
+                # elif (
+                #     response.status == 403
+                # ):  # Not authorized (bad email address or authorization cookie)
+                #     raise CloudError("Not authorized")
+                # elif response.status == 404:
+                #     raise CloudError("Fireplace not found (bad serial number)")
+                # elif response.status == 422:
+                #     raise CloudError(
+                #         "Invalid Parameter (invalid command id or command value)"
+                #     )
+                else:
+                    raise CommandRejectedError(
+                        f"Unexpected return code {response.status}"
+                    )
 
     async def long_poll(self) -> bool:
         """Perform a LongPoll to wait for a Status update.
@@ -194,9 +234,11 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
         long_poll_url = f"{self.prefix}://iftapi.net/a/{self._serial}/applongpoll"
         self._log.debug(f"long_poll() {long_poll_url}")
 
-        async with self._get_session() as session:
+        async with self._session_context(timeout_seconds=61) as session:
             try:
-                response = await session.get(long_poll_url, timeout=ClientTimeout(61))
+                response = await session.get(
+                    long_poll_url, timeout=ClientTimeout(total=61)
+                )
 
                 self._log.debug("Long Poll Status Code %d", response.status)
                 if response.status == 200:
@@ -288,9 +330,11 @@ class IntelliFireAPICloud(IntelliFireController, IntelliFireDataProvider):
         poll_url = f"{self.prefix}://iftapi.net/a/{self._serial}//apppoll"
 
         self._log.debug(f"poll() {poll_url}")
-        async with self._get_session() as session:
+        async with self._session_context(timeout_seconds=timeout_seconds) as session:
             try:
-                response = await session.get(poll_url)
+                response = await session.get(
+                    poll_url, timeout=ClientTimeout(total=timeout_seconds)
+                )
                 response.raise_for_status()  # Handle 4xx/5xx responses here
                 json_data = await response.json()
                 self._data = IntelliFirePollData(**json_data)

--- a/intellifire4py/cloud_interface.py
+++ b/intellifire4py/cloud_interface.py
@@ -9,7 +9,7 @@ import aiohttp
 
 from .const import USER_AGENT
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
 
 from intellifire4py import (
     IntelliFireAPICloud,
@@ -41,23 +41,33 @@ class IntelliFireCloudInterface:
     _cloud_fireplaces: dict[str, IntelliFireAPICloud] = {}
     _is_logged_in = False
 
-    def __init__(self, use_http: bool = False, verify_ssl: bool = True):
+    def __init__(
+        self,
+        use_http: bool = False,
+        verify_ssl: bool = True,
+        session: ClientSession | None = None,
+        timeout_seconds: float = 10.0,
+    ):
         """Initializes the IntelliFireCloudInterface with optional HTTP settings.
 
         Args:
             use_http (bool, optional): If True, use HTTP instead of HTTPS. Default is False.
             verify_ssl (bool, optional): If True, enable SSL certificate verification. Default is True.
+            session (ClientSession | None): Optional externally managed aiohttp session.
+            timeout_seconds (float): Timeout for sessions created by this class.
         """
 
         self._use_http = use_http
         self._verify_ssl = verify_ssl
+        self._timeout_seconds = timeout_seconds
 
         if use_http:
             self.prefix = "http"  # pragma: no cover
         else:
             self.prefix = "https"
 
-        self._session: ClientSession | None = None
+        self._session: ClientSession | None = session
+        self._owns_session = session is None
         self._in_context = False
 
     async def __aenter__(self) -> IntelliFireCloudInterface:
@@ -78,14 +88,18 @@ class IntelliFireCloudInterface:
 
     async def _create_session(self) -> None:
         """Create an aiohttp ClientSession with the required settings."""
-        if self._session is None or self._session.closed:
+        if self._session is None or (self._owns_session and self._session.closed):
             self._session = ClientSession(
                 headers={"user-agent": USER_AGENT},
+                timeout=ClientTimeout(total=self._timeout_seconds),
+                connector=TCPConnector(ssl=self._verify_ssl),
             )
+        elif self._session.closed:
+            raise RuntimeError("Session is closed")
 
     async def close_session(self) -> None:
         """Close the aiohttp ClientSession."""
-        if self._session and not self._session.closed:
+        if self._owns_session and self._session and not self._session.closed:
             await self._session.close()
 
     # async def login_with_cookie_vars(
@@ -258,6 +272,7 @@ class IntelliFireCloudInterface:
                     use_http=self._use_http,
                     verify_ssl=self._verify_ssl,
                     cookie_jar=self.user_data.cookie_jar,
+                    session=self._session,
                 )
 
                 # Poll the fireplace
@@ -353,6 +368,7 @@ class IntelliFireCloudInterface:
                 cookie_jar=common_fireplace.cookie_jar,
                 use_http=self.use_http,
                 verify_ssl=self.verify_ssl,
+                session=self._session,
             )
             for common_fireplace in self._user_data.fireplaces
         ]

--- a/intellifire4py/exceptions.py
+++ b/intellifire4py/exceptions.py
@@ -5,6 +5,22 @@ class CloudError(Exception):
     """Error with the API call."""
 
 
+class CommandError(Exception):
+    """Base error for command failures."""
+
+
+class MissingCredentialsError(CommandError):
+    """Command cannot be sent because credentials are missing."""
+
+
+class CommandRejectedError(CommandError):
+    """Fireplace or cloud service rejected a command."""
+
+
+class CommandRetryError(CommandError):
+    """Command could not be sent after retry attempts."""
+
+
 class InputRangError(Exception):
     """Input out of bounds."""
 

--- a/intellifire4py/local_api.py
+++ b/intellifire4py/local_api.py
@@ -18,6 +18,7 @@ from intellifire4py.model import (
 from .const import IntelliFireCommand
 from .const import IntelliFireApiMode
 from .control import IntelliFireController
+from .exceptions import CommandRetryError, MissingCredentialsError
 from .read import IntelliFireDataProvider
 from .utils import _range_check
 import aiohttp
@@ -229,7 +230,7 @@ class IntelliFireAPILocal(IntelliFireController, IntelliFireDataProvider):
                 command.name,
                 value,
             )
-            return
+            raise MissingCredentialsError("Missing user_id or api_key")
 
         was_running = await self.stop_background_polling()
         self._log.debug(
@@ -237,11 +238,12 @@ class IntelliFireAPILocal(IntelliFireController, IntelliFireDataProvider):
             was_running,
         )
 
-        await self._send_local_command(command=command, value=value)
-
-        if was_running:
-            await self.start_background_polling()
-            self._log.info("send_command:: Restarting background polling")
+        try:
+            await self._send_local_command(command=command, value=value)
+        finally:
+            if was_running:
+                await self.start_background_polling()
+                self._log.info("send_command:: Restarting background polling")
 
     def _construct_payload(self, command: str, value: int, challenge: str) -> str:
         """Construct a payload."""
@@ -345,6 +347,9 @@ class IntelliFireAPILocal(IntelliFireController, IntelliFireDataProvider):
                     "_send_local_command:: FAILURE!! - IntelliFire command could not be sent [%s=%s]",
                     command.value["local_command"],
                     value,
+                )
+                raise CommandRetryError(
+                    f"Command {command.name} could not be sent after {retries} retries"
                 )
 
     async def _get_challenge(self, session: ClientSession) -> str | None:

--- a/tests/test_cloud_api_extended.py
+++ b/tests/test_cloud_api_extended.py
@@ -3,13 +3,18 @@
 import pytest
 import json
 import pytest_asyncio
+import aiohttp
 from aiohttp import CookieJar, ClientResponseError, RequestInfo
 from aioresponses import aioresponses
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from intellifire4py.cloud_api import IntelliFireAPICloud
-from intellifire4py.exceptions import CloudError
+from intellifire4py.exceptions import (
+    CloudError,
+    CommandRejectedError,
+    MissingCredentialsError,
+)
 from intellifire4py.const import IntelliFireCloudPollType, IntelliFireCommand
 from intellifire4py.model import IntelliFirePollData
 
@@ -136,7 +141,10 @@ async def test_send_command_no_cookie_jar():
         cookie_jar=None,
     )
 
-    await api.send_command(command=IntelliFireCommand.POWER, value=1)
+    with pytest.raises(MissingCredentialsError):
+        await api.flame_on()
+
+    assert api.data.is_on is False
 
 
 @pytest.mark.asyncio
@@ -148,7 +156,7 @@ async def test_send_cloud_command_unexpected_status(cloud_api):
             status=500,
         )
 
-        with pytest.raises(ClientResponseError):
+        with pytest.raises(CommandRejectedError):
             await cloud_api._send_cloud_command(
                 command=IntelliFireCommand.POWER, value=1
             )
@@ -190,6 +198,33 @@ async def test_poll_404_not_found(cloud_api):
 
         with pytest.raises(ClientResponseError):
             await cloud_api.poll()
+
+
+@pytest.mark.asyncio
+async def test_poll_uses_external_session(cloud_poll_json: str) -> None:
+    """Test poll uses but does not own a caller-provided session."""
+    async with aiohttp.ClientSession() as session:
+        api = IntelliFireAPICloud(
+            serial="TEST123",
+            use_http=False,
+            verify_ssl=True,
+            cookie_jar=CookieJar(),
+            session=session,
+        )
+
+        with aioresponses() as m:
+            m.get(
+                "https://iftapi.net/a/TEST123//apppoll",
+                status=200,
+                body=cloud_poll_json,
+            )
+
+            await api.poll(timeout_seconds=1)
+
+        await api.close_session()
+
+        assert api.data.name == "Living Room"
+        assert session.closed is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_cloud_interface_extended.py
+++ b/tests/test_cloud_interface_extended.py
@@ -1,6 +1,7 @@
 """Extended tests for cloud_interface.py to improve coverage."""
 
 import pytest
+import aiohttp
 from aiohttp import ClientError
 from aioresponses import aioresponses
 
@@ -69,3 +70,63 @@ async def test_context_manager_usage():
         RuntimeError, match="must be called within an 'async with' context"
     ):
         await cloud_interface.login_with_credentials(username="user", password="pass")
+
+
+@pytest.mark.asyncio
+async def test_context_manager_does_not_close_external_session() -> None:
+    """Test caller-provided sessions remain caller-owned."""
+    async with aiohttp.ClientSession() as session:
+        cloud_interface = IntelliFireCloudInterface(session=session)
+
+        async with cloud_interface:
+            assert cloud_interface._session is session
+
+        assert session.closed is False
+
+
+@pytest.mark.asyncio
+async def test_create_session_applies_timeout_and_ssl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test owned sessions receive configured timeout and SSL verification."""
+    created_kwargs: dict[str, object] = {}
+    created_connector_ssl_values: list[bool] = []
+
+    class FakeConnector:
+        """Fake aiohttp connector for constructor inspection."""
+
+        def __init__(self, *, ssl: bool) -> None:
+            """Initialize the fake connector."""
+            self.ssl = ssl
+            created_connector_ssl_values.append(ssl)
+
+    class FakeSession:
+        """Fake aiohttp session for constructor inspection."""
+
+        closed = False
+
+        def __init__(self, **kwargs) -> None:
+            """Store constructor keyword arguments."""
+            created_kwargs.update(kwargs)
+
+        async def close(self) -> None:
+            """Close the fake session."""
+            self.closed = True
+
+    monkeypatch.setattr("intellifire4py.cloud_interface.TCPConnector", FakeConnector)
+    monkeypatch.setattr("intellifire4py.cloud_interface.ClientSession", FakeSession)
+
+    cloud_interface = IntelliFireCloudInterface(
+        verify_ssl=False,
+        timeout_seconds=7.5,
+    )
+
+    await cloud_interface._create_session()
+    await cloud_interface.close_session()
+
+    timeout = created_kwargs["timeout"]
+    assert isinstance(timeout, aiohttp.ClientTimeout)
+    assert timeout.total == 7.5
+    assert created_connector_ssl_values == [False]
+    assert cloud_interface._session is not None
+    assert cloud_interface._session.closed is True

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -11,7 +11,7 @@ from yarl import URL
 
 from intellifire4py.cloud_api import IntelliFireAPICloud
 from intellifire4py.local_api import IntelliFireAPILocal
-from intellifire4py.exceptions import CloudError
+from intellifire4py.exceptions import CloudError, CommandRetryError
 from intellifire4py.const import IntelliFireCommand
 from intellifire4py.udp import UDPFireplaceFinder
 
@@ -20,6 +20,18 @@ def _make_request_info(url: str, method: str = "GET") -> RequestInfo:
     return RequestInfo(
         url=URL(url), method=method, headers=CIMultiDictProxy(CIMultiDict())
     )
+
+
+def _make_fast_time():
+    """Return a time.time() mock that runs one post attempt per retry."""
+    count = 0
+
+    def fake_time():
+        nonlocal count
+        count += 1
+        return 100.0 if count % 5 == 0 else 0.0
+
+    return fake_time
 
 
 @pytest_asyncio.fixture
@@ -78,7 +90,11 @@ async def test_local_api_poll_timeout_error():
 @pytest.mark.asyncio
 async def test_local_api_send_command_challenge_timeout():
     """Test send_command when challenge retrieval times out repeatedly."""
-    api = IntelliFireAPILocal(fireplace_ip="192.168.1.100")
+    api = IntelliFireAPILocal(
+        fireplace_ip="192.168.1.100",
+        user_id="test_user",
+        api_key="deadbeefdeadbeefdeadbeefdeadbeef",
+    )
 
     with aioresponses() as m:
         # All challenge requests timeout
@@ -88,14 +104,19 @@ async def test_local_api_send_command_challenge_timeout():
             repeat=True,
         )
 
-        # This should eventually give up after retries
-        await api.send_command(command=IntelliFireCommand.POWER, value=1)
+        with patch("intellifire4py.local_api.asyncio.sleep"):
+            with pytest.raises(CommandRetryError):
+                await api.send_command(command=IntelliFireCommand.POWER, value=1)
 
 
 @pytest.mark.asyncio
 async def test_local_api_send_command_post_failure():
     """Test send_command when post request fails."""
-    api = IntelliFireAPILocal(fireplace_ip="192.168.1.100")
+    api = IntelliFireAPILocal(
+        fireplace_ip="192.168.1.100",
+        user_id="test_user",
+        api_key="deadbeefdeadbeefdeadbeefdeadbeef",
+    )
 
     with aioresponses() as m:
         # Challenge succeeds
@@ -112,8 +133,10 @@ async def test_local_api_send_command_post_failure():
             repeat=True,
         )
 
-        # Should retry and eventually give up
-        await api.send_command(command=IntelliFireCommand.POWER, value=1)
+        with patch("intellifire4py.local_api.time.time", side_effect=_make_fast_time()):
+            with patch("intellifire4py.local_api.asyncio.sleep"):
+                with pytest.raises(CommandRetryError):
+                    await api.send_command(command=IntelliFireCommand.POWER, value=1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -9,6 +9,7 @@ from aioresponses import aioresponses
 from intellifire4py.cloud_api import IntelliFireAPICloud
 from intellifire4py.cloud_interface import IntelliFireCloudInterface
 from intellifire4py.const import IntelliFireCommand
+from intellifire4py.exceptions import CommandRetryError
 from intellifire4py.local_api import IntelliFireAPILocal
 
 
@@ -131,9 +132,10 @@ async def test_local_send_command_all_retries_exhausted(local_api):
 
         with patch("intellifire4py.local_api.asyncio.sleep"):
             with patch.object(local_api._log, "debug") as mock_debug:
-                await local_api._send_local_command(
-                    command=IntelliFireCommand.POWER, value=1
-                )
+                with pytest.raises(CommandRetryError):
+                    await local_api._send_local_command(
+                        command=IntelliFireCommand.POWER, value=1
+                    )
                 debug_calls = [str(c) for c in mock_debug.call_args_list]
                 assert any("FAILURE" in c for c in debug_calls)
 

--- a/tests/test_local_api_extended.py
+++ b/tests/test_local_api_extended.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from aioresponses import aioresponses
 import aiohttp
 
+from intellifire4py.exceptions import CommandRetryError, MissingCredentialsError
 from intellifire4py.local_api import IntelliFireAPILocal
 
 
@@ -69,13 +70,37 @@ async def test_send_command_needs_login():
     """Test send_command when login is needed."""
     api = IntelliFireAPILocal(fireplace_ip="192.168.1.100")
 
-    from intellifire4py.const import IntelliFireCommand
-
     with aioresponses() as m:
         m.get("http://192.168.1.100/get_challenge", status=200, body="challenge123")
         m.post("http://192.168.1.100/post", status=200)
 
-        await api.send_command(command=IntelliFireCommand.POWER, value=1)
+        with pytest.raises(MissingCredentialsError):
+            await api.flame_on()
+
+        assert api.data.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_send_command_raises_after_retries() -> None:
+    """Test send_command raises when local retries are exhausted."""
+    api = IntelliFireAPILocal(
+        fireplace_ip="192.168.1.100",
+        user_id="test_user",
+        api_key="deadbeefdeadbeefdeadbeefdeadbeef",
+    )
+
+    with aioresponses() as m:
+        m.get(
+            "http://192.168.1.100/get_challenge",
+            exception=asyncio.TimeoutError(),
+            repeat=True,
+        )
+
+        with patch("intellifire4py.local_api.asyncio.sleep"):
+            with pytest.raises(CommandRetryError):
+                await api.flame_on()
+
+    assert api.data.is_on is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add caller-owned aiohttp ClientSession support for cloud APIs without closing external sessions
- apply explicit timeouts and SSL verification to library-created cloud sessions
- add typed command errors for missing credentials, rejected cloud commands, and exhausted local retries
- prevent optimistic cached state updates when command sends fail
- document the unreleased behavior change in CHANGELOG.md

## Tests
- uv run pytest
- uv run ruff check .
- uv run mypy intellifire4py
- commit hooks: pyupgrade, codespell, ruff, ruff format, mypy, ty, conventional commit

## Home Assistant compatibility
Successful commands should continue to work. Failed commands now raise typed intellifire4py CommandError subclasses instead of silently returning, so HA should get a companion PR that catches those errors in entity command paths and raises HomeAssistantError with a clean user-facing message before bumping manifest.json.